### PR TITLE
Feature/ios10 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,13 +35,6 @@ stamp-h1
 src/.libs
 docs/html
 libimobiledevice-1.0.pc
-dev/.libs/*
-dev/afccheck
-dev/ideviceclient
-dev/idevicesyslog
-dev/lckd-client
-dev/msyncclient
-dev/ideviceenterrecovery
 tools/.libs/*
 tools/idevice_id
 tools/ideviceinfo
@@ -58,6 +51,8 @@ tools/idevicename
 tools/idevicepair
 tools/ideviceprovision
 tools/idevicecrashreport
+tools/idevicedebug
+tools/idevicenotificationproxy
 cython/.libs/*
 cython/*.c
 doxygen.cfg

--- a/common/utils.h
+++ b/common/utils.h
@@ -33,6 +33,8 @@
 #include <stdio.h>
 #include <plist/plist.h>
 
+#define MAC_EPOCH 978307200
+
 #ifndef HAVE_STPCPY
 char *stpcpy(char *s1, const char *s2);
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,6 @@ AC_PROG_LIBTOOL
 PKG_CHECK_MODULES(libusbmuxd, libusbmuxd >= $LIBUSBMUXD_VERSION)
 PKG_CHECK_MODULES(libplist, libplist >= $LIBPLIST_VERSION)
 PKG_CHECK_MODULES(libplistmm, libplist++ >= $LIBPLISTMM_VERSION)
-AC_CHECK_LIB(pthread, [pthread_create, pthread_mutex_lock], [AC_SUBST(libpthread_LIBS,[-lpthread])], [AC_MSG_ERROR([libpthread is required to build libimobiledevice])])
 
 # Checks for header files.
 AC_HEADER_STDC
@@ -82,6 +81,10 @@ case ${host_os} in
 esac
 AM_CONDITIONAL(WIN32, test x$win32 = xtrue)
 
+if test "x$win32" != xtrue; then
+  AC_CHECK_LIB(pthread, [pthread_create, pthread_mutex_lock], [AC_SUBST(libpthread_LIBS,[-lpthread])], [AC_MSG_ERROR([libpthread is required to build libimobiledevice])])
+fi
+
 # Cython Python Bindings
 AC_ARG_WITH([cython],
             [AS_HELP_STRING([--without-cython],
@@ -120,7 +123,7 @@ AC_SUBST([CYTHON_SUB])
 AC_ARG_ENABLE([openssl],
             [AS_HELP_STRING([--disable-openssl],
             [Do not look for OpenSSL])],
-            [use_openssl=no],
+            [use_openssl=$enableval],
             [use_openssl=yes])
 
 pkg_req_openssl="openssl >= 0.9.8"

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -239,6 +239,16 @@ idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
  */
 idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
 
+/**
+ * Get the underlying file descriptor for a connection
+ *
+ * @param connection The connection to get fd of
+ * @param fd Pointer to an int where the fd is stored
+ *
+ * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
+ */
+idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd);
+
 /* misc */
 
 /**

--- a/src/diagnostics_relay.c
+++ b/src/diagnostics_relay.c
@@ -104,6 +104,7 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_free(dia
 	if (property_list_service_client_free(client->parent) != PROPERTY_LIST_SERVICE_E_SUCCESS) {
 		return DIAGNOSTICS_RELAY_E_UNKNOWN_ERROR;
 	}
+	free(client);
 	return DIAGNOSTICS_RELAY_E_SUCCESS;
 }
 

--- a/src/file_relay.c
+++ b/src/file_relay.c
@@ -59,6 +59,7 @@ LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_free(file_relay_client
 	if (property_list_service_client_free(client->parent) != PROPERTY_LIST_SERVICE_E_SUCCESS) {
 		return FILE_RELAY_E_UNKNOWN_ERROR;
 	}
+	free(client);
 	return FILE_RELAY_E_SUCCESS;
 }
 

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -463,6 +463,22 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive(idevice_connecti
 	return internal_connection_receive(connection, data, len, recv_bytes);
 }
 
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd)
+{
+	if (!connection || !fd) {
+		return IDEVICE_E_INVALID_ARG;
+	}
+
+	idevice_error_t result = IDEVICE_E_UNKNOWN_ERROR;
+	if (connection->type == CONNECTION_USBMUXD) {
+		*fd = (int)(long)connection->data;
+		result = IDEVICE_E_SUCCESS;
+	} else {
+		debug_info("Unknown connection type %d", connection->type);
+	}
+	return result;
+}
+
 LIBIMOBILEDEVICE_API idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle)
 {
 	if (!device)
@@ -626,7 +642,11 @@ static const char *ssl_error_to_string(int e)
 /**
  * Internally used gnutls callback function that gets called during handshake.
  */
+#if GNUTLS_VERSION_NUMBER >= 0x020b07
+static int internal_cert_callback(gnutls_session_t session, const gnutls_datum_t * req_ca_rdn, int nreqs, const gnutls_pk_algorithm_t * sign_algos, int sign_algos_length, gnutls_retr2_st * st)
+#else
 static int internal_cert_callback(gnutls_session_t session, const gnutls_datum_t * req_ca_rdn, int nreqs, const gnutls_pk_algorithm_t * sign_algos, int sign_algos_length, gnutls_retr_st * st)
+#endif
 {
 	int res = -1;
 	gnutls_certificate_type_t type = gnutls_certificate_type_get(session);
@@ -634,7 +654,12 @@ static int internal_cert_callback(gnutls_session_t session, const gnutls_datum_t
 		ssl_data_t ssl_data = (ssl_data_t)gnutls_session_get_ptr(session);
 		if (ssl_data && ssl_data->host_privkey && ssl_data->host_cert) {
 			debug_info("Passing certificate");
+#if GNUTLS_VERSION_NUMBER >= 0x020b07
+			st->cert_type = type;
+			st->key_type = GNUTLS_PRIVKEY_X509;
+#else
 			st->type = type;
+#endif
 			st->ncerts = 1;
 			st->cert.x509 = &ssl_data->host_cert;
 			st->key.x509 = ssl_data->host_privkey;
@@ -678,7 +703,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_enable_ssl(idevice_conne
 	}
 	BIO_set_fd(ssl_bio, (int)(long)connection->data, BIO_NOCLOSE);
 
-	SSL_CTX *ssl_ctx = SSL_CTX_new(SSLv3_method());
+	SSL_CTX *ssl_ctx = SSL_CTX_new(TLSv1_method());
 	if (ssl_ctx == NULL) {
 		debug_info("ERROR: Could not create SSL context.");
 		BIO_free(ssl_bio);
@@ -743,7 +768,11 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_enable_ssl(idevice_conne
 	debug_info("enabling SSL mode");
 	errno = 0;
 	gnutls_certificate_allocate_credentials(&ssl_data_loc->certificate);
+#if GNUTLS_VERSION_NUMBER >= 0x020b07
+	gnutls_certificate_set_retrieve_function(ssl_data_loc->certificate, internal_cert_callback);
+#else
 	gnutls_certificate_client_set_retrieve_function(ssl_data_loc->certificate, internal_cert_callback);
+#endif
 	gnutls_init(&ssl_data_loc->session, GNUTLS_CLIENT);
 	gnutls_priority_set_direct(ssl_data_loc->session, "NONE:+VERS-SSL3.0:+ANON-DH:+RSA:+AES-128-CBC:+AES-256-CBC:+SHA1:+MD5:+COMP-NULL", NULL);
 	gnutls_credentials_set(ssl_data_loc->session, GNUTLS_CRD_CERTIFICATE, ssl_data_loc->certificate);

--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -847,11 +847,12 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_status_get_error(plist_t status
 
 LIBIMOBILEDEVICE_API void instproxy_status_get_name(plist_t status, char **name)
 {
-	*name = NULL;
 	if (name) {
 		plist_t node = plist_dict_get_item(status, "Status");
 		if (node) {
 			plist_get_string_val(node, name);
+		} else {
+			*name = NULL;
 		}
 	}
 }
@@ -907,10 +908,13 @@ LIBIMOBILEDEVICE_API void instproxy_status_get_current_list(plist_t status, uint
 
 LIBIMOBILEDEVICE_API void instproxy_command_get_name(plist_t command, char** name)
 {
-	*name = NULL;
-	plist_t node = plist_dict_get_item(command, "Command");
-	if (node) {
-		plist_get_string_val(node, name);
+	if (name) {
+		plist_t node = plist_dict_get_item(command, "Command");
+		if (node) {
+			plist_get_string_val(node, name);
+		} else {
+			*name = NULL;
+		}
 	}
 }
 

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -637,7 +637,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_name(lockdownd_clien
 
 LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label)
 {
-	if (!client)
+	if (!device || !client)
 		return LOCKDOWN_E_INVALID_ARG;
 
 	static struct lockdownd_service_descriptor service = {

--- a/tools/idevicebackup.c
+++ b/tools/idevicebackup.c
@@ -251,7 +251,7 @@ static plist_t mobilebackup_factory_info_plist_new(const char* udid)
 	if (value_node)
 		plist_dict_set_item(ret, "IMEI", plist_copy(value_node));
 
-	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL), 0));
+	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL) - MAC_EPOCH, 0));
 
 	value_node = plist_dict_get_item(root_node, "ProductType");
 	plist_dict_set_item(ret, "Product Type", plist_copy(value_node));
@@ -288,7 +288,7 @@ static void mobilebackup_info_update_last_backup_date(plist_t info_plist)
 		return;
 
 	node = plist_dict_get_item(info_plist, "Last Backup Date");
-	plist_set_date_val(node, time(NULL), 0);
+	plist_set_date_val(node, time(NULL) - MAC_EPOCH, 0);
 
 	node = NULL;
 }

--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -146,10 +146,10 @@ static void mobilebackup_afc_get_file_contents(afc_client_t afc, const char *fil
 		uint32_t bread = 0;
 		afc_file_read(afc, f, buf+done, 65536, &bread);
 		if (bread > 0) {
+			done += bread;
 		} else {
 			break;
 		}
-		done += bread;
 	}
 	if (done == fsize) {
 		*size = fsize;
@@ -223,7 +223,7 @@ static plist_t mobilebackup_factory_info_plist_new(const char* udid, lockdownd_c
 	if (value_node)
 		plist_dict_set_item(ret, "IMEI", plist_copy(value_node));
 
-	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL), 0));
+	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL) - MAC_EPOCH, 0));
 
 	value_node = plist_dict_get_item(root_node, "PhoneNumber");
 	if (value_node && (plist_get_node_type(value_node) == PLIST_STRING)) {
@@ -914,7 +914,8 @@ static void mb2_handle_list_directory(mobilebackup2_client_t mobilebackup2, plis
 				}
 				plist_dict_set_item(fdict, "DLFileType", plist_new_string(ftype));
 				plist_dict_set_item(fdict, "DLFileSize", plist_new_uint(st.st_size));
-				plist_dict_set_item(fdict, "DLFileModificationDate", plist_new_date(st.st_mtime, 0));
+				plist_dict_set_item(fdict, "DLFileModificationDate",
+						    plist_new_date(st.st_mtime - MAC_EPOCH, 0));
 
 				plist_dict_set_item(dirlist, ep->d_name, fdict);
 				free(fpath);

--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -317,16 +317,14 @@ int main(int argc, char *argv[])
 			instproxy_client_free(instproxy_client);
 			instproxy_client = NULL;
 
-			if (container) {
-				if (plist_get_node_type(container) == PLIST_STRING) {
-					plist_get_string_val(container, &working_directory);
-					debug_info("working_directory: %s\n", working_directory);
-					plist_free(container);
-				} else {
-						plist_free(container);
-					fprintf(stderr, "Could not determine container path for bundle identifier %s.\n", bundle_identifier);
-					goto cleanup;
-				}
+			if (container && (plist_get_node_type(container) == PLIST_STRING)) {
+				plist_get_string_val(container, &working_directory);
+				debug_info("working_directory: %s\n", working_directory);
+				plist_free(container);
+			} else {
+				plist_free(container);
+				fprintf(stderr, "Could not determine container path for bundle identifier %s.\n", bundle_identifier);
+				goto cleanup;
 			}
 
 			/* start and connect to debugserver */


### PR DESCRIPTION
Note: Merged in latest master from libimobiledevice mainline.

`idevicebackup2` was failing to remove the Snapshots dir because it had some empty dirs inside of it. 

We can resolve this by using nftw to walk the ‘Snapshots’ and remove
empty subdirs first instead of just calling `remove()`. 